### PR TITLE
Bump pdfbox from 2.0.13 to 2.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.13</version>
+            <version>2.0.15</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bumps pdfbox from 2.0.13 to 2.0.15.

Signed-off-by: dependabot[bot] <support@github.com>